### PR TITLE
update for node 0.5 support

### DIFF
--- a/examples/nodejs-test.js
+++ b/examples/nodejs-test.js
@@ -1,7 +1,5 @@
 // Import the optparse script
-require.paths.unshift(__dirname); //make local paths accessible
-
-var optparse = require('lib/optparse');
+var optparse = require('../lib/optparse');
 
 var sys= require('sys');
 

--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -80,7 +80,7 @@ function build_rules(filters, arr) {
                 rule = build_rule(filters, r[0]);
                 break;
             case 2:
-                var expr = LONG_SWITCH_RE(r[0]) ? 0 : 1;
+                var expr = LONG_SWITCH_RE.test(r[0]) ? 0 : 1;
                 var alias = expr == 0 ? -1 : 0;
                 var desc = alias == -1 ? 1 : -1;
                 rule = build_rule(filters, r[alias], r[expr], r[desc]);
@@ -118,7 +118,7 @@ function build_rule(filters, short, expr, desc) {
     if(m[2] != undefined) {
         // A switch argument is expected. Check if the argument is optional,
         // then find a filter that suites.
-        var optional_match = ARG_OPTIONAL_RE(m[2]);
+        var optional_match = ARG_OPTIONAL_RE.test(m[2]);
         var filter_name = optional_match === null ? m[2] : optional_match[1];
         optional = optional_match !== null;
         filter = filters[filter_name];
@@ -141,7 +141,7 @@ function build_rule(filters, short, expr, desc) {
 function contains_expr(arr) {
     if(!arr || !arr.length) return false;
     var l = arr.length;
-    while(l-- > 0) if(LONG_SWITCH_RE(arr[l])) return true;
+    while(l-- > 0) if(LONG_SWITCH_RE.test(arr[l])) return true;
     return false;
 }
 
@@ -224,7 +224,7 @@ OptionParser.prototype = {
         var rules = build_rules(this.filters, this._rules);
         var tokens = args.concat([]);
         while((token = tokens.shift()) && this._halt == false) {
-            if(LONG_SWITCH_RE(token) || SHORT_SWITCH_RE(token)) {
+            if(LONG_SWITCH_RE.test(token) || SHORT_SWITCH_RE.test(token)) {
                 var arg = undefined;
                 // The token is a long or a short switch. Get the corresponding 
                 // rule, filter and handle it. Pass the switch to the default 
@@ -234,7 +234,7 @@ OptionParser.prototype = {
                     if(rule.long == token || rule.short == token) {
                         if(rule.filter !== undefined) {
                             arg = tokens.shift();
-                            if(!LONG_SWITCH_RE(arg) && !SHORT_SWITCH_RE(arg)) {
+                            if(!LONG_SWITCH_RE.test(arg) && !SHORT_SWITCH_RE.test(arg)) {
                                 try {
                                     arg = rule.filter(arg);
                                 } catch(e) {


### PR DESCRIPTION
- remove shifting paths and require file directly
- call .test for regex instead of treating regex like a function
