### PR TITLE
1 bugfix, 1 new feature

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -289,11 +289,10 @@ OptionParser.prototype = {
             if(rule.decl.length > longest) longest = rule.decl.length;
         }
         for(var i = 0; i < rules.length; i++) {
-            var text;
+            var text = spaces(6);
             rule = rules[i];
             if(shorts) {
                 if(rule.short) text = spaces(2) + rule.short + ', ';
-                else text = spaces(6);
             }
             text += spaces(rule.decl, longest) + spaces(3);
             text += rule.desc;

--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -223,7 +223,8 @@ OptionParser.prototype = {
         var result = [], callback;
         var rules = build_rules(this.filters, this._rules);
         var tokens = args.concat([]);
-        while((token = tokens.shift()) && this._halt == false) {
+        var token;
+        while(this._halt == false && (token = tokens.shift())) {
             if(LONG_SWITCH_RE.test(token) || SHORT_SWITCH_RE.test(token)) {
                 var arg = undefined;
                 // The token is a long or a short switch. Get the corresponding
@@ -261,7 +262,7 @@ OptionParser.prototype = {
                 if(callback) callback.apply(this, [token]);
             }
         }
-        return this._halt ? this.on_halt.apply(this, []) : result;
+        return this._halt ? this.on_halt.apply(this, [tokens]) : result;
     },
 
     // Returns an Array with all defined option rules


### PR DESCRIPTION
This pull request fixes issue #3.  The fix is just an uninitialized variable.

The pull request also adds a new feature to the halt callback.  My goal was to be able to make a command which had global options, then a command, then suboptions:

```
bin/mycommand --global=aaa sub1 --sub1-specific
bin/mycommand --global=bbb sub2 --sub2-specific
```

So I wanted to parse the command line up until (and including) the first word (`parser.on(2, ...)`.  A halt() seems the correct thing to do, but the "remaining, unparsed arguments" are lost. So I decided to pass them in the halt event handler.  That way, I can make a new parser with different options to parse the remainder of the arguments.
