### PR TITLE
Add clobbered `optional_match` back.

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -119,6 +119,7 @@ function build_rule(filters, short, expr, desc) {
         // A switch argument is expected. Check if the argument is optional,
         // then find a filter that suites.
         var optional = ARG_OPTIONAL_RE.test(m[2]);
+        var optional_match = m[2].match(ARG_OPTIONAL_RE);
         var filter_name = optional ? optional_match[1] : m[2];
         filter = filters[filter_name];
         if(filter === undefined) filter = filters[DEFAULT_FILTER];


### PR DESCRIPTION
Add back `optional_match`, which got lost somewhere in the mix.
