### PR TITLE
Fix error when using shortest configuration

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -73,11 +73,11 @@ PREDEFINED_FILTERS['EMAIL'] = filter_email;
 function build_rules(filters, arr) {
     var rules = [];
     for(var i=0; i<arr.length; i++) {
-        var r = arr[i], rule
+        var r = arr[i], rule;
         if(!contains_expr(r)) throw OptError('Rule MUST contain an option.');
         switch(r.length) {
             case 1:
-                rule = build_rule(filters, r[0]);
+                rule = build_rule(filters, undefined, r[0]);
                 break;
             case 2:
                 var expr = LONG_SWITCH_RE.test(r[0]) ? 0 : 1;
@@ -92,7 +92,7 @@ function build_rules(filters, arr) {
             case 0:
                 continue;
         }
-        rules.push(rule)
+        rules.push(rule);
     }
     return rules;
 }


### PR DESCRIPTION
The rule expression should be passed to `build_rule` as third argument, not second.

```
TypeError: Cannot call method 'match' of undefined
```
