### PR TITLE
Fix missing argument validation on last option

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -235,7 +235,7 @@ OptionParser.prototype = {
                     if(rule.long == token || rule.short == token) {
                         if(rule.filter !== undefined) {
                             arg = tokens.shift();
-                            if(!LONG_SWITCH_RE.test(arg) && !SHORT_SWITCH_RE.test(arg)) {
+                            if(arg && (!LONG_SWITCH_RE.test(arg) && !SHORT_SWITCH_RE.test(arg))) {
                                 try {
                                     arg = rule.filter(arg);
                                 } catch(e) {

--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -242,7 +242,9 @@ OptionParser.prototype = {
                                     throw OptError(token + ': ' + e.toString());
                                 }
                             } else if(rule.optional_arg) {
-                                tokens.unshift(arg);
+                                if(arg) {
+                                    tokens.unshift(arg);
+                                }
                             } else {
                                 throw OptError('Expected switch argument.');
                             }


### PR DESCRIPTION
Normally, omitting an argument to a switch yields in a `OptError("Expected switch argument")`. Example code

```
var OptionParser = require('optparse').OptionParser;

var parser = new OptionParser([['-e', '--example STRING']]);
parser.parse(['--example', '--test']);
```

This does as you would expect and throws. However, calling `parser.parse(['--example']);` will not throw even though the argument to `example` is mandatory and missing. This is because the `arg` is `undefined` so neither `LONG_SWITCH_RE` nor `SHORT_SWITCH_RE` match it.
