### PR TITLE
Pass the list of unparsed tokens to the filter

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -237,7 +237,7 @@ OptionParser.prototype = {
                             arg = tokens.shift();
                             if(!LONG_SWITCH_RE.test(arg) && !SHORT_SWITCH_RE.test(arg)) {
                                 try {
-                                    arg = rule.filter(arg);
+                                    arg = rule.filter(arg, tokens);
                                 } catch(e) {
                                     throw OptError(token + ': ' + e.toString());
                                 }


### PR DESCRIPTION
This is not a bugfix but a feature request. I wanted to be able to have an option that accepts multiple arguments. With this change, I’m able to write a filter for this:

```
var parser = new OptionParser([['-e', '--example ARRAY']]);

parser.filter('array', function(arg, tokens) {
  var result = [arg];
  var token;
  while((token = tokens.shift()) && token.indexOf('-') !== 0) {
    result.push(token);
  }
  if(token) {
    tokens.unshift(token);
  }
  return result;
});
```
