### PR TITLE
Reset arg if it was a switch and not an argument

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -245,6 +245,7 @@ OptionParser.prototype = {
                                 if(arg) {
                                     tokens.unshift(arg);
                                 }
+                                arg = undefined;
                             } else {
                                 throw OptError('Expected switch argument.');
                             }


### PR DESCRIPTION
The following:

```
var parser = new OptionParser([['-e', '--example [STRING]']]);
parser.parse(['--example', '--help']);
```

passes `"--help"` as arg to the `example` handler even though the `--help` switch will be handled later on. This patch fixes this and passes `undefined` to the `example` handler function.

Note: merging this will most likely conflict with pull request #14. Ultimately it should not make much difference whether you put the `arg = undefined;` inside or below the `if` block.
