### PR TITLE
Added ability to add callback inside the switch definition

### DIFF
--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -88,6 +88,9 @@ function build_rules(filters, arr) {
             case 3:
                 rule = build_rule(filters, r[0], r[1], r[2]);
                 break;
+			case 4:
+				rule = build_rule(filters, r[0], r[1], r[2], r[3]);
+				break;
             default:
             case 0:
                 continue;
@@ -108,9 +111,10 @@ function build_rules(filters, arr) {
 //      desc               The optional help section for the switch
 //      optional_arg       Indicates that switch argument is optional
 //      filter             The filter to use when parsing the arg. An
+//		callback           The callback for when flag is used
 //                         <<undefined>> value means that the switch does
 //                         not take anargument.
-function build_rule(filters, short, expr, desc) {
+function build_rule(filters, short, expr, desc, callback) {
     var optional, filter;
     var m = expr.match(EXT_RULE_RE);
     if(m == null) throw OptError('The switch is not well-formed.');
@@ -131,7 +135,8 @@ function build_rule(filters, short, expr, desc) {
         decl: expr,
         desc: desc,
         optional_arg: optional,
-        filter: filter
+        filter: filter,
+		callback: callback
     }
 }
 
@@ -250,6 +255,7 @@ OptionParser.prototype = {
                             }
                         }
                         callback = this.on_switches[rule.name];
+						if(rule.callback) rule.callback.apply(this, [rule.name, arg])
                         if (!callback) callback = this.on_switches['*'];
                         if(callback) callback.apply(this, [rule.name, arg]);
                         break;


### PR DESCRIPTION
Usage: 

``` coffeescript
    switches = [
      ['-h', '--help', 'Show Help']
      ['-i', '--interval [INTERVAL]', 'Ping Interval', (key, val)->
        console.log "Interval is" + val
      ]
      ['-s', '--packetsize NUMBER', 'Packetsize', (key, val)->
        console.log "Packet Size is " + val
      ]
    ]
```

This removes some duplicate code.
